### PR TITLE
Use pluggable map to lower build size

### DIFF
--- a/__tests__/nyc/ol/Basemap.test.js
+++ b/__tests__/nyc/ol/Basemap.test.js
@@ -3,7 +3,7 @@ import Basemap from 'nyc/ol/Basemap'
 import LocalStorage from 'nyc/ol/LocalStorage'
 import BasemapHelper from 'nyc/BasemapHelper'
 
-import OlMap from 'ol/Map'
+import OlMap from 'ol/PluggableMap'
 import OlView from 'ol/View'
 import OlLayerTile from 'ol/layer/Tile'
 import OlSourceXYZ from 'ol/source/XYZ'

--- a/src/nyc/ol/Basemap.js
+++ b/src/nyc/ol/Basemap.js
@@ -9,7 +9,22 @@ import nycOl from 'nyc/ol'
 import BasemapHelper from 'nyc/BasemapHelper'
 import LocalStorage from 'nyc/ol/LocalStorage'
 
-import OlMap from 'ol/Map'
+import OlPluggableMap from 'ol/PluggableMap'
+
+import CanvasMapRenderer from 'ol/renderer/canvas/Map'
+import CanvasTileLayerRenderer from 'ol/renderer/canvas/TileLayer'
+import CanvasVectorLayerRenderer from 'ol/renderer/canvas/VectorLayer'
+
+import DoubleClickZoom from 'ol/interaction/DoubleClickZoom'
+import DragPan from 'ol/interaction/DragPan'
+import DragRotate from 'ol/interaction/DragRotate'
+import DragZoom from 'ol/interaction/DragZoom'
+import KeyboardPan from 'ol/interaction/KeyboardPan'
+import KeyboardZoom from 'ol/interaction/KeyboardZoom'
+import MouseWheelZoom from 'ol/interaction/MouseWheelZoom'
+import PinchRotate from 'ol/interaction/PinchRotate'
+import PinchZoom from 'ol/interaction/PinchZoom'
+
 import OlView from 'ol/View'
 import OlSourceXYZ from 'ol/source/XYZ'
 import OlLayerTile from 'ol/layer/Tile'
@@ -27,7 +42,7 @@ olProjRegister(proj4)
  * @mixes module:nyc/BasemapHelper~BasemapHelper
  * @see http://openlayers.org/en/latest/apidoc/ol.Map.html
  */
-class Basemap extends OlMap {
+class Basemap extends OlPluggableMap {
   /**
    * @desc Create an instance of Basemap
    * @public
@@ -38,6 +53,19 @@ class Basemap extends OlMap {
   constructor(options, preload) {
     const viewProvided = options.view instanceof OlView
     Basemap.setupView(options)
+    if (!options.interactions) {
+      options.interactions = [
+        new DragRotate(),
+        new DoubleClickZoom(),
+        new DragPan(),
+        new PinchRotate(),
+        new PinchZoom(),
+        new KeyboardPan(),
+        new KeyboardZoom(),
+        new MouseWheelZoom(),
+        new DragZoom()
+      ];
+    }
     super(options)
     nyc.mixin(this, [BasemapHelper])
     /**
@@ -68,6 +96,14 @@ class Basemap extends OlMap {
     this.setupLayers(options, preload)
     this.defaultExtent(viewProvided)
     this.hookupEvents(this.getTargetElement())
+  }
+  createRenderer() {
+    const renderer = new CanvasMapRenderer(this);
+    renderer.registerLayerRenderers([
+      CanvasTileLayerRenderer,
+      CanvasVectorLayerRenderer,
+    ]);
+    return renderer;
   }
   /**
    * @desc Show photo layer


### PR DESCRIPTION
If we use the normal ol map, we get all the interactions included in the build, e.g. also the modify interaction, which we are not using.

I've added some interactions in this PR, but the exact list is up for discussion with @timkeane 

Also, the list of pluggable renderers is what I found to be used in the hurricane app. I am not sure if there are other apps using e.g. vector tile layers. If so, we would need to add those as well.