### PR TITLE
Add script for automating basic changelog template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+## 1.3.68
+05b44cc Fix facility marker bug - custom image urls can be used with FrameworkMap 3189c95 Upgrade build helper

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,5 @@
+PACKAGE_VERSION=$(jq -r ".version" package.json)
+echo '##' ${PACKAGE_VERSION} >> CHANGELOG.md
+git fetch --tags
+LOG=$(git log $(git describe --tags --abbrev=0)..HEAD --pretty=format:"%h %s")
+echo ${LOG} >> CHANGELOG.md


### PR DESCRIPTION
This PR includes a basic template for automating a change log. The changelog.sh script retrieves the log of the most recent commits from the last pushed tag, and gets the current version from the package.json file. It then pipes this output to CHANGELOG.md.
Ideally this script would be a part of a git hook (perhaps a pre-commit or pre-push).
See #13 for original issue.